### PR TITLE
Fix IN operator

### DIFF
--- a/lib/geoffrey/parsers/text.ex
+++ b/lib/geoffrey/parsers/text.ex
@@ -57,9 +57,13 @@ defmodule Geoffrey.Parsers.Text do
     field_path = String.split(field, ".")
 
     compare_to =
-      compare_to
-      |> String.split("#")
-      |> parse_compare_to()
+      case String.split(compare_to, ",") do
+        [value] ->
+          parse_compare_to_value(value)
+
+        [_ | _] = value_list ->
+          Enum.map(value_list, &parse_compare_to_value/1)
+      end
 
     case valid_condition?(comparator, field_path, compare_to) do
       true ->
@@ -68,6 +72,13 @@ defmodule Geoffrey.Parsers.Text do
       _ ->
         {:error, condition}
     end
+  end
+
+  @spec parse_compare_to_value(String.t()) :: integer() | float() | String.t()
+  defp parse_compare_to_value(value) do
+    value
+    |> String.split("#")
+    |> parse_compare_to()
   end
 
   # Valida que la condicion se haya parseado correctamente

--- a/lib/geoffrey/parsers/text.ex
+++ b/lib/geoffrey/parsers/text.ex
@@ -48,7 +48,6 @@ defmodule Geoffrey.Parsers.Text do
     |> String.split("\n")
     |> Enum.map(&parse_condition/1)
     |> Enum.filter(&elem(&1, 0))
-    |> Enum.map(&elem(&1, 1))
   end
 
   # Crea una condicion a partir de una cadena de caracteres

--- a/lib/geoffrey/rules/condition/comparators.ex
+++ b/lib/geoffrey/rules/condition/comparators.ex
@@ -37,8 +37,8 @@ defmodule Geoffrey.Rules.Condition.Comparators do
 
   def get("in") do
     fn
-      value, compare_to when is_list(value) ->
-        compare_to in value
+      value, compare_to when is_list(compare_to) ->
+        value in compare_to
 
       _, _ ->
         false

--- a/test/geoffrey_test.exs
+++ b/test/geoffrey_test.exs
@@ -106,14 +106,21 @@ defmodule GeoffreyTest do
     assert %Rule{result: %{has_bbva_debt?: true}} = Rule.eval(rule1, input)
   end
 
-  test "Test IN comparator" do
-    condition = Condition.new("in", ["value"], 1)
+  test "Test ANY comparator" do
+    condition = Condition.new("any", ["value"], 1)
 
     assert true ==
              Condition.eval(condition, [
                %{"value" => 1, "desc" => "uno"},
                %{"value" => 2, "desc" => "dos"}
              ])
+  end
+
+  test "Test IN comparator" do
+    condition = Condition.new("in", ["value"], [1, 2, 3])
+
+    assert Condition.eval(condition, %{"value" => 1, "desc" => "uno"})
+    assert Condition.eval(condition, %{"value" => 2, "desc" => "dos"})
   end
 
   test "Should find field correctly for condition" do

--- a/test/txt_test.exs
+++ b/test/txt_test.exs
@@ -17,4 +17,16 @@ defmodule TxtTest do
     assert [{:ok, c1}, {:ok, c2}] ==
              Text.parse("eq|entity|bbva\nneq|personal_information.country|mx")
   end
+
+  test "Parsing IN condition" do
+    c1 = Condition.new("any", ["dir", "value"], [1, 2, 3])
+
+    assert [{:ok, c1}] == Text.parse("any|dir.value|i#1,i#2,i#3")
+  end
+
+  test "Parsing ANY condition" do
+    c1 = Condition.new("any", ["dir", "value"], 1)
+
+    assert [{:ok, c1}] == Text.parse("any|dir.value|i#1")
+  end
 end


### PR DESCRIPTION
## Context

The IN operator was written incorrectly and it was working as the ANY operator.

This also adds parsing conditions from text for IN operators where the value needs to be a list. These values will be saved as a string where they are separated by commas.

`in|some.value|i#1,i#2`

> Yes, this can cause some problems if we try to to use values with commas but for now we will be okay