### PR TITLE
Define a parser behaviour and refactor code

### DIFF
--- a/lib/geoffrey/parsers/nl.ex
+++ b/lib/geoffrey/parsers/nl.ex
@@ -9,7 +9,10 @@ defmodule Geoffrey.Parsers.NL do
 
   import NimbleParsec
 
+  alias Geoffrey.Parsers.ParserBehaviour
   alias Geoffrey.Rules.Condition
+
+  @behaviour ParserBehaviour
 
   comparator =
     choice([
@@ -50,16 +53,16 @@ defmodule Geoffrey.Parsers.NL do
 
   defparsec(:rule, condition |> wrap() |> repeat())
 
-  @spec parse(String.t()) :: {:ok, Condition.t()} | {:error, String.t()}
+  @impl true
   def parse(conditions) do
     case rule(conditions) do
       {:ok, [_ | _] = conditions, _, _, _, _} ->
         Enum.map(conditions, fn [comparator, field_path, compare_to] ->
-          {:ok, Condition.new(comparator, field_path, compare_to)}
+          Condition.new(comparator, field_path, compare_to)
         end)
 
       _ ->
-        {:error, conditions}
+        []
     end
   end
 end

--- a/lib/geoffrey/parsers/parser_behaviour.ex
+++ b/lib/geoffrey/parsers/parser_behaviour.ex
@@ -1,0 +1,14 @@
+defmodule Geoffrey.Parsers.ParserBehaviour do
+  @moduledoc """
+  Define all the required functions that should be implemented
+  for a valid parser
+  """
+
+  alias Geoffrey.Rules.Condition
+
+  @doc """
+  For a given string return all the valid parsed conditions as a list
+  and ignore all the invalid ones
+  """
+  @callback parse(raw_condition :: String.t()) :: [Condition.t()]
+end

--- a/lib/geoffrey/parsers/text.ex
+++ b/lib/geoffrey/parsers/text.ex
@@ -35,19 +35,20 @@ defmodule Geoffrey.Parsers.Text do
 
   """
 
+  alias Geoffrey.Parsers.ParserBehaviour
   alias Geoffrey.Rules.Condition
+
+  @behaviour ParserBehaviour
 
   defguard is_empty(value) when value == "" or is_nil(value)
 
-  @doc """
-  Convierte una cadena de caracteres en una o varias condiciones
-  """
-  @spec parse(String.t()) :: [Condition.t()]
-  def parse(condition) do
-    condition
+  @impl true
+  def parse(raw_condition) do
+    raw_condition
     |> String.split("\n")
     |> Enum.map(&parse_condition/1)
-    |> Enum.filter(&elem(&1, 0))
+    |> Enum.filter(&(elem(&1, 0) == :ok))
+    |> Enum.map(&elem(&1, 1))
   end
 
   # Crea una condicion a partir de una cadena de caracteres

--- a/lib/geoffrey/rule.ex
+++ b/lib/geoffrey/rule.ex
@@ -50,13 +50,12 @@ defmodule Geoffrey.Rule do
   @doc """
   Agrega una condicion a la regla
   """
-  @spec add_condition(__MODULE__.t(), String.t() | Condition.t() | [String.t()] | [Condition.t()]) :: __MODULE__.t()
+  @spec add_condition(__MODULE__.t(), String.t() | Condition.t() | [String.t()] | [Condition.t()]) ::
+          __MODULE__.t()
   def add_condition(rule, condition) when is_binary(condition) do
-    parsed_conditions = Condition.parse(condition)
-
-    parsed_conditions
-    |> Enum.reject(fn {status, _condition} -> status == :error end)
-    |> Enum.reduce(rule, fn {_, condition}, updated_rule ->
+    condition
+    |> Condition.parse()
+    |> Enum.reduce(rule, fn condition, updated_rule ->
       add_condition(updated_rule, condition)
     end)
   end

--- a/test/geoffrey_test.exs
+++ b/test/geoffrey_test.exs
@@ -6,28 +6,26 @@ defmodule GeoffreyTest do
   alias Geoffrey.Rules.Condition
 
   test "Condition txt parsing" do
-    assert [{:ok, %Condition{comparator: "gt", compare_to: 18, field: ["age"]}}] ==
+    assert [%Condition{comparator: "gt", compare_to: 18, field: ["age"]}] ==
              Condition.parse("|gt|age|i#18")
 
     assert [
-             {:ok,
-              %Condition{comparator: "lt", field: ["personal_information", "age"], compare_to: 30}}
+             %Condition{comparator: "lt", field: ["personal_information", "age"], compare_to: 30}
            ] ==
              Condition.parse("|lt|personal_information.age|i#30")
 
     assert [
-             {:ok,
-              %Condition{
-                comparator: "neq",
-                field: ["nested", "2_nested", "3_nested"],
-                compare_to: 14.59
-              }}
+             %Condition{
+               comparator: "neq",
+               field: ["nested", "2_nested", "3_nested"],
+               compare_to: 14.59
+             }
            ] ==
              Condition.parse("|neq|nested.2_nested.3_nested|f#14.59")
   end
 
   test "Condition NL parsing" do
-    assert [{:ok, %Condition{comparator: "gt", compare_to: "18", field: ["age"]}}] ==
+    assert [%Condition{comparator: "gt", compare_to: "18", field: ["age"]}] ==
              Condition.parse("gt age, 18")
   end
 

--- a/test/txt_test.exs
+++ b/test/txt_test.exs
@@ -7,26 +7,25 @@ defmodule TxtTest do
   test "Parsing a condition" do
     condition = Condition.new("eq", ["entity"], "bbva")
 
-    assert [{:ok, condition}] == Text.parse("eq|entity|bbva")
+    assert [condition] == Text.parse("eq|entity|bbva")
   end
 
   test "Parsing multiple conditions" do
     c1 = Condition.new("eq", ["entity"], "bbva")
     c2 = Condition.new("neq", ["personal_information", "country"], "mx")
 
-    assert [{:ok, c1}, {:ok, c2}] ==
-             Text.parse("eq|entity|bbva\nneq|personal_information.country|mx")
+    assert [c1, c2] == Text.parse("eq|entity|bbva\nneq|personal_information.country|mx")
   end
 
   test "Parsing IN condition" do
     c1 = Condition.new("any", ["dir", "value"], [1, 2, 3])
 
-    assert [{:ok, c1}] == Text.parse("any|dir.value|i#1,i#2,i#3")
+    assert [c1] == Text.parse("any|dir.value|i#1,i#2,i#3")
   end
 
   test "Parsing ANY condition" do
     c1 = Condition.new("any", ["dir", "value"], 1)
 
-    assert [{:ok, c1}] == Text.parse("any|dir.value|i#1")
+    assert [c1] == Text.parse("any|dir.value|i#1")
   end
 end


### PR DESCRIPTION
Text parser and NL parser weren't sharing the same specs, both should
be used in the same way, that why we needed a behaviour to define a
generics functions that both modules should implement

Some refactor was needed to make the code match the new behaviour