### PR TITLE
Implement ANY (OR) evaluation mode

### DIFF
--- a/lib/geoffrey/rule.ex
+++ b/lib/geoffrey/rule.ex
@@ -1,8 +1,6 @@
 defmodule Geoffrey.Rule do
   alias Geoffrey.Rules.Condition
 
-  @type eval_mode :: :all | :any
-
   @enforce_keys [:name]
   defstruct [
     :name,
@@ -16,6 +14,7 @@ defmodule Geoffrey.Rule do
     {:errors, []}
   ]
 
+  @type eval_mode :: :all | :any
   @type t :: %__MODULE__{
           name: String.t(),
           desc: String.t(),

--- a/lib/geoffrey/rule.ex
+++ b/lib/geoffrey/rule.ex
@@ -133,8 +133,12 @@ defmodule Geoffrey.Rule do
 
   # Evalua las condiciones de una regla
   @spec eval_conditions(__MODULE__.t(), map()) :: boolean()
-  defp eval_conditions(%__MODULE__{conditions: conditions}, input) do
+  defp eval_conditions(%__MODULE__{validation_type: :all, conditions: conditions}, input) do
     Enum.all?(conditions, &Condition.eval(&1, input))
+  end
+
+  defp eval_conditions(%__MODULE__{validation_type: :any, conditions: conditions}, input) do
+    Enum.any?(conditions, &Condition.eval(&1, input))
   end
 
   # Ejecuta las acciones asignadas si la regla es valida

--- a/lib/geoffrey/rule.ex
+++ b/lib/geoffrey/rule.ex
@@ -1,10 +1,13 @@
 defmodule Geoffrey.Rule do
   alias Geoffrey.Rules.Condition
 
+  @typep validation_type :: :all | :any
+
   @enforce_keys [:name]
   defstruct [
     :name,
     :desc,
+    {:validation_type, :all},
     {:priority, 0},
     {:conditions, []},
     {:actions, []},
@@ -16,6 +19,7 @@ defmodule Geoffrey.Rule do
   @type t :: %__MODULE__{
           name: String.t(),
           desc: String.t(),
+          validation_type: validation_type(),
           priority: integer(),
           conditions: [],
           actions: []
@@ -45,6 +49,14 @@ defmodule Geoffrey.Rule do
   @spec set_priority(__MODULE__.t(), integer()) :: __MODULE__.t()
   def set_priority(rule, priority) when is_integer(priority) do
     %{rule | priority: priority}
+  end
+
+  @doc """
+  Actualiza la prioridad de una regla. El valor debe ser un numero entero
+  """
+  @spec set_validation_type(__MODULE__.t(), validation_type()) :: __MODULE__.t()
+  def set_validation_type(rule, validation_type) when is_integer(validation_type) do
+    %{rule | validation_type: validation_type}
   end
 
   @doc """

--- a/lib/geoffrey/rule.ex
+++ b/lib/geoffrey/rule.ex
@@ -1,13 +1,13 @@
 defmodule Geoffrey.Rule do
   alias Geoffrey.Rules.Condition
 
-  @typep validation_type :: :all | :any
+  @typep eval_mode :: :all | :any
 
   @enforce_keys [:name]
   defstruct [
     :name,
     :desc,
-    {:validation_type, :all},
+    {:eval_mode, :all},
     {:priority, 0},
     {:conditions, []},
     {:actions, []},
@@ -19,7 +19,7 @@ defmodule Geoffrey.Rule do
   @type t :: %__MODULE__{
           name: String.t(),
           desc: String.t(),
-          validation_type: validation_type(),
+          eval_mode: eval_mode(),
           priority: integer(),
           conditions: [],
           actions: []
@@ -54,9 +54,9 @@ defmodule Geoffrey.Rule do
   @doc """
   Actualiza la prioridad de una regla. El valor debe ser un numero entero
   """
-  @spec set_validation_type(__MODULE__.t(), validation_type()) :: __MODULE__.t()
-  def set_validation_type(rule, validation_type) when is_integer(validation_type) do
-    %{rule | validation_type: validation_type}
+  @spec set_eval_mode(__MODULE__.t(), eval_mode()) :: __MODULE__.t()
+  def set_eval_mode(rule, eval_mode) when is_integer(eval_mode) do
+    %{rule | eval_mode: eval_mode}
   end
 
   @doc """
@@ -133,11 +133,11 @@ defmodule Geoffrey.Rule do
 
   # Evalua las condiciones de una regla
   @spec eval_conditions(__MODULE__.t(), map()) :: boolean()
-  defp eval_conditions(%__MODULE__{validation_type: :all, conditions: conditions}, input) do
+  defp eval_conditions(%__MODULE__{eval_mode: :all, conditions: conditions}, input) do
     Enum.all?(conditions, &Condition.eval(&1, input))
   end
 
-  defp eval_conditions(%__MODULE__{validation_type: :any, conditions: conditions}, input) do
+  defp eval_conditions(%__MODULE__{eval_mode: :any, conditions: conditions}, input) do
     Enum.any?(conditions, &Condition.eval(&1, input))
   end
 

--- a/lib/geoffrey/rule.ex
+++ b/lib/geoffrey/rule.ex
@@ -1,7 +1,7 @@
 defmodule Geoffrey.Rule do
   alias Geoffrey.Rules.Condition
 
-  @typep eval_mode :: :all | :any
+  @type eval_mode :: :all | :any
 
   @enforce_keys [:name]
   defstruct [

--- a/lib/geoffrey/rule.ex
+++ b/lib/geoffrey/rule.ex
@@ -55,7 +55,7 @@ defmodule Geoffrey.Rule do
   Actualiza la prioridad de una regla. El valor debe ser un numero entero
   """
   @spec set_eval_mode(__MODULE__.t(), eval_mode()) :: __MODULE__.t()
-  def set_eval_mode(rule, eval_mode) when is_integer(eval_mode) do
+  def set_eval_mode(rule, eval_mode) when eval_mode in [:all, :any] do
     %{rule | eval_mode: eval_mode}
   end
 

--- a/lib/geoffrey/rule_group.ex
+++ b/lib/geoffrey/rule_group.ex
@@ -24,7 +24,7 @@ defmodule Geoffrey.RuleGroup do
   @doc """
   Actualiza el tipo de grupo de reglas
   """
-  @spec set_eval_mode(__MODULE__.t(), atom()) :: __MODULE__.t()
+  @spec set_eval_mode(__MODULE__.t(), Rule.eval_mode()) :: __MODULE__.t()
   def set_eval_mode(%__MODULE__{} = rule_group, eval_mode) when eval_mode in [:all, :any] do
     %{rule_group | eval_mode: eval_mode}
   end

--- a/lib/geoffrey/rule_group.ex
+++ b/lib/geoffrey/rule_group.ex
@@ -3,32 +3,30 @@ defmodule Geoffrey.RuleGroup do
 
   defstruct rules: [],
             valid?: false,
-            type: :all,
+            eval_mode: :all,
             result: nil
 
   @type t :: %__MODULE__{
           rules: [Rule.t()],
           valid?: boolean(),
-          type: atom(),
+          eval_mode: atom(),
           result: [any()]
         }
-
-  @valid_types ~w(all any)a
 
   @doc """
   Crea un nuevo grupo de reglas
   """
   @spec new :: __MODULE__.t()
   def new do
-    %__MODULE__{type: :any}
+    %__MODULE__{eval_mode: :any}
   end
 
   @doc """
   Actualiza el tipo de grupo de reglas
   """
-  @spec set_type(__MODULE__.t(), atom()) :: __MODULE__.t()
-  def set_type(%__MODULE__{} = rule_group, type) when type in @valid_types do
-    %{rule_group | type: type}
+  @spec set_eval_mode(__MODULE__.t(), atom()) :: __MODULE__.t()
+  def set_eval_mode(%__MODULE__{} = rule_group, eval_mode) when eval_mode in [:all, :any] do
+    %{rule_group | eval_mode: eval_mode}
   end
 
   @doc """
@@ -73,7 +71,7 @@ defmodule Geoffrey.RuleGroup do
   # que el grupo sea valido.
   # Si el grupo es de tipo `any` con que alguna regla evalue el grupo sera valido
   @spec eval_rules(__MODULE__.t(), map()) :: __MODULE__.t()
-  defp eval_rules(%__MODULE__{type: :all, rules: rules} = rule_group, input) do
+  defp eval_rules(%__MODULE__{eval_mode: :all, rules: rules} = rule_group, input) do
     rules_evaluations = Enum.map(rules, &Rule.eval(&1, input))
 
     case Enum.all?(rules_evaluations, & &1.valid?) do
@@ -82,11 +80,11 @@ defmodule Geoffrey.RuleGroup do
         %{rule_group | valid?: true, result: result}
 
       _ ->
-        rule_group
+        %{rule_group | valid?: false, result: nil}
     end
   end
 
-  defp eval_rules(%__MODULE__{type: :any, rules: rules} = rule_group, input) do
+  defp eval_rules(%__MODULE__{eval_mode: :any, rules: rules} = rule_group, input) do
     valid_rule =
       Enum.find(rules, fn rule ->
         %Rule{valid?: valid?} = Rule.eval(rule, input)
@@ -95,10 +93,10 @@ defmodule Geoffrey.RuleGroup do
 
     case valid_rule do
       nil ->
-        false
+        %{rule_group | valid?: false, result: nil}
 
-      %{result: result} = _rule ->
-        %{rule_group | result: result}
+      %Rule{result: result} ->
+        %{rule_group | valid?: true, result: result}
     end
   end
 

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Geoffrey.MixProject do
   def project do
     [
       app: :geoffrey,
-      version: "0.2.3",
+      version: "0.3.0",
       elixir: "~> 1.11",
       start_permanent: Mix.env() == :prod,
       aliases: aliases(),

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Geoffrey.MixProject do
   def project do
     [
       app: :geoffrey,
-      version: "0.2.2",
+      version: "0.2.3",
       elixir: "~> 1.11",
       start_permanent: Mix.env() == :prod,
       aliases: aliases(),

--- a/test/geoffrey_test.exs
+++ b/test/geoffrey_test.exs
@@ -36,6 +36,7 @@ defmodule GeoffreyTest do
       "regla_prueba"
       |> Rule.new("Una prueba")
       |> Rule.set_priority(1)
+      |> Rule.set_eval_mode(:any)
       |> Rule.add_condition("|gt|age|i#30")
       |> Rule.add_condition(condition)
       |> Rule.add_action(:example)
@@ -52,14 +53,19 @@ defmodule GeoffreyTest do
   end
 
   test "Rule eval" do
-    invalid_input = %{
+    input = %{
+      "age" => 35,
+      "height" => 1.85
+    }
+
+    input_2 = %{
       "age" => 30,
       "height" => 1.85
     }
 
-    input = %{
-      "age" => 35,
-      "height" => 1.85
+    invalid_input = %{
+      "age" => 30,
+      "height" => 1.84
     }
 
     condition = Condition.new("eq", ["height"], 1.85)
@@ -68,6 +74,7 @@ defmodule GeoffreyTest do
       "regla_prueba"
       |> Rule.new("Una prueba")
       |> Rule.set_priority(1)
+      |> Rule.set_eval_mode(:any)
       |> Rule.add_condition("|gt|age|i#30")
       |> Rule.add_condition(condition)
       |> Rule.add_action(fn x -> Map.put(x, "type", :example) end)
@@ -75,6 +82,9 @@ defmodule GeoffreyTest do
 
     %Rule{result: result} = Geoffrey.Rule.eval(rule, input)
     assert %{"type" => :example, "valid?" => true} = result
+
+    assert %Rule{valid?: true} = Geoffrey.Rule.eval(rule, input_2)
+
     assert %Rule{valid?: false} = Geoffrey.Rule.eval(rule, invalid_input)
 
     input = %{


### PR DESCRIPTION
## Context

Until now rules can only be evaluated as a whole as ANDs (where all conditions have to be true). Now with the `eval_mode` you can choose for rules to be evaluated where only one of the conditions needs to be true.